### PR TITLE
Pretorian primo

### DIFF
--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -613,7 +613,7 @@
 
 /datum/keybinding/xeno/scatter_spit
 	name = "scatter_spit"
-	full_name = "Spitter: Scatter Spit"
+	full_name = "Scatter Spit"
 	description = "Fires a scattershot of 6 acid globules which create acid puddles on impact or at the end of their range."
 	keybind_signal = COMSIG_XENOABILITY_SCATTER_SPIT
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -133,7 +133,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	action_icon_state = "scatter_spit"
 	mechanics_text = "Spits a spread of acid projectiles that splatter on the ground."
 	ability_name = "scatter spit"
-	plasma_cost = 250
+	plasma_cost = 280
 	cooldown_timer = 0.5 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_SCATTER_SPIT,
@@ -226,7 +226,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	if(!(target.flags_pass))
 		target.flags_pass &= ~PASSMOB
 
-	target.ParalyzeNoChain(0.5 SECONDS) //Extremely brief, we don't want them to take 289732 ticks of acid
+	target.ParalyzeNoChain(0.1 SECONDS) //Extremely brief, we don't want them to take 289732 ticks of acid
 
 	to_chat(target, span_highdanger("The [owner] tackles us, sending us behind them!"))
 	owner.visible_message(span_xenodanger("\The [owner] tackles [target], swapping location with them!"), \

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -212,6 +212,7 @@
 		/datum/action/xeno_action/activable/corrosive_acid,
 		/datum/action/xeno_action/activable/xeno_spit,
 		/datum/action/xeno_action/activable/spray_acid/cone,
+		/datum/action/xeno_action/activable/scatter_spit/praetorian,
 		/datum/action/xeno_action/activable/acid_dash,
 		/datum/action/xeno_action/pheromones,
 		/datum/action/xeno_action/pheromones/emit_recovery,


### PR DESCRIPTION
## About The Pull Request
Обновляет примо преторианца, теперь при получении примо, он получает старый ацид дешь, в котором увеличено время на второй прыжок с 2 до 6 но уменьшен стан с 0.5 до 0.1 
А также способность спитера Scatter Spit, с кд меньшем чем у спитера, а именно 0.5.
## Why It's Good For The Game
Выправляет баланс между разными ветками развития спитера, теперь будет стоять реальный выбор между преторианцем и бойлером.
## Changelog
Преторианец:
 Acid dash: время на второй прыжок после первого, увеличено с 2 до 6
 Scatter Spit: Новая способность, даётся после получения примо, механически такая же как у спитера, но кд 0.5.
:cl:
add: Теперь встретить преторианца в плотной застройке, это по настоящему страшно. Если ты конечно не носишь с собой дробовик.
/:cl: