### PR TITLE
Rava super rage 50% heal

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -301,6 +301,11 @@
 
 	if(X.health < 0) //If we're at less than 0 HP, it's time to max rage.
 		rage_power = 1
+		var/total_damage = X.getFireLoss() + X.getBruteLoss()
+		var/burn_percentile_damage = X.getFireLoss() / total_damage
+		var/brute_percentile_damage = X.getBruteLoss() / total_damage
+		X.setBruteLoss((X.xeno_caste.max_health/2) * brute_percentile_damage)
+		X.setFireLoss((X.xeno_caste.max_health/2) * burn_percentile_damage)
 
 	var/rage_power_radius = CEILING(rage_power * 7, 1) //Define radius of the SFX
 


### PR DESCRIPTION
## About The Pull Request
При нажатии супер рейджа, супер рейдж устанавливает раве 50 процентов максимального хп.
## Why It's Good For The Game
Баф равагера, самого бесполезного т3 ксеноса. (вдовы для меня не существует)
Это не приведёт к тому что рава выйдет из под контроля, зачастую ты можешь нажать супер рейдж 1/2 раза за раунд который длится 1.5 часа. (по крайне мере, раньше мог, теперь возможно будет больше возможностей)
Так же это не бафнет раву не в супер рейдже, т.е силу ты сможешь получить если всё выйдет идеально (отыграл хорошо - получил награду, звучит честно, нет?)
Если рава выйдет из под контроля при двух его бафах (этот, и возвращение модификатора 1 на супер ярость) Можно будет подумать над нерфом одного из этих аспектов или обоих. Это не будет проблемой.
:cl:
add: Рава теперь сможет дратся после прожатия супер рейджа, с меньшим риском сразу сдохнуть.
/:cl:

