### PR TITLE
Nest range nerf/fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -285,6 +285,11 @@
 			to_chat(X, span_warning("Resin doors need a wall or resin door next to them to stand up."))
 			return fail_activate()
 
+	if(X.selected_resin == /obj/structure/bed/nest)
+		for(var/obj/structure/bed/nest/xeno_nest in range (2,X))
+			to_chat(X, span_warning("Another nest is too close!"))
+			return fail_activate()
+
 	if(!do_after(X, get_wait(), TRUE, T, BUSY_ICON_BUILD))
 		return fail_activate()
 


### PR DESCRIPTION
## About The Pull Request
Теперь нельзя строить ксено несты рядом друг с другом, только если между ними расстояние 2 клетки.

## Why It's Good For The Game
Больше не будет уродливых полос нестов вместо травы.
Но поставить нест что бы перетащить мара в крите всё ещё не сложно.

Если будет стоять вопрос с дистанцией между нестами, всегда можно будет поменять на меньшее/большее значение.


:cl:
balance: 2 dist range for nest
/:cl:
