### PR TITLE
Негативный рост таймлоков

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -153,10 +153,10 @@ GLOBAL_LIST_INIT(jobs_fallen_all, typecacheof(list(/datum/job/fallen)))
 
 // In minutes
 #define XP_REQ_NOVICE 300
-#define XP_REQ_UNSEASONED 600
-#define XP_REQ_INTERMEDIATE 1500
-#define XP_REQ_EXPERIENCED 6000
-#define XP_REQ_EXPERT 6000
+#define XP_REQ_UNSEASONED 300
+#define XP_REQ_INTERMEDIATE 600
+#define XP_REQ_EXPERIENCED 2400
+#define XP_REQ_EXPERT 2400
 #define XP_REQ_SURVIVOR 18000
 
 // how much a job is going to contribute towards burrowed larva. see config for points required to larva. old balance was 1 larva per 3 humans.


### PR DESCRIPTION

## About The Pull Request

Всё ещё в несколько раз выше чем на оффах, но в несколько раз меньше, чем на тгмс***.

Можно принять это изменение на время, а после снова вернуть к слишком большим значением, когда старые игроки наберут снова большое количество часов. 

## Why It's Good For The Game

В раунде будут не только морпехи, админам чуть реже придётся выдавать роли через кнопки

:cl:
balance: rebalanced timelocks
/:cl:
